### PR TITLE
Replaced split() with explode(). Fixes #3.

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -107,7 +107,7 @@ class syntax_plugin_stars2 extends DokuWiki_Syntax_Plugin {
             $empty = true;
 
             // Get seperate num's
-            $num=split('/',$num); // Strip size
+            $num=explode('/',$num); // Strip size
             if (!isset($num[1])) 
                 $num[1] = $num[0];
             


### PR DESCRIPTION
Fixes broken PHP 7.0 compatibility.
Please check and merge.
